### PR TITLE
Improve category/products changelog index performance

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh.php
@@ -1,0 +1,18 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Category_Refresh
+    extends Enterprise_Catalog_Model_Index_Action_Catalog_Category_Product_Category_Refresh
+{
+    use SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect;
+
+    /**
+     * Retrieve select for reindex products of non anchor categories
+     *
+     * @param Mage_Core_Model_Store $store
+     * @return Varien_Db_Select
+     */
+    protected function _getAnchorCategoriesSelect(Mage_Core_Model_Store $store)
+    {
+        return $this->_getFasterAnchorCategoriesSelect($store);
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
@@ -4,6 +4,15 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Catego
     extends Enterprise_Catalog_Model_Index_Action_Catalog_Category_Product_Category_Refresh_Changelog
 {
     use SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect;
+    use SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck;
+
+    /**
+     * Publish data from tmp to index
+     */
+    protected function _publishData()
+    {
+        return $this->_publishDataWithCheck();
+    }
 
     /**
      * Retrieve a select for reindexing products of anchor categories

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
@@ -15,6 +15,23 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Catego
     }
 
     /**
+     * Reindex category/product index by store
+     *
+     * @return $this
+     */
+    protected function _reindex()
+    {
+        if (!empty($this->_limitationByCategories)) {
+            return parent::_reindex();
+        } else {
+            $this->_beforeReindex();
+            $this->_afterReindex();
+
+            return $this;
+        }
+    }
+
+    /**
      * Retrieve a select for reindexing products of anchor categories
      *
      * @param Mage_Core_Model_Store $store

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
@@ -6,7 +6,7 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Catego
     use SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect;
 
     /**
-     * Retrieve select for reindex products of non anchor categories
+     * Retrieve a select for reindexing products of anchor categories
      *
      * @param Mage_Core_Model_Store $store
      * @return Varien_Db_Select
@@ -15,5 +15,47 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Catego
     {
         $select = $this->_getFasterAnchorCategoriesSelect($store);
         return $select->where('cc.entity_id IN (?)', $this->_limitationByCategories);
+    }
+
+    /**
+     * Reindex products of non anchor categories
+     *
+     * @param Mage_Core_Model_Store $store
+     */
+    protected function _reindexNonAnchorCategories(Mage_Core_Model_Store $store)
+    {
+        // Optimization: don't do anything if there are no categories in the limit.
+        // We would add a IN (NULL) anyway, so we would do nothing.
+        if (!empty($this->_limitationByCategories)) {
+            return parent::_reindexNonAnchorCategories($store);
+        }
+    }
+
+    /**
+     * Reindex products of anchor categories
+     *
+     * @param Mage_Core_Model_Store $store
+     */
+    protected function _reindexAnchorCategories(Mage_Core_Model_Store $store)
+    {
+        // Optimization: don't do anything if there are no categories in the limit.
+        // We would add a IN (NULL) anyway, so we would do nothing.
+        if (!empty($this->_limitationByCategories)) {
+            return parent::_reindexAnchorCategories($store);
+        }
+    }
+
+    /**
+     * Reindex all products to root category
+     *
+     * @param Mage_Core_Model_Store $store
+     */
+    protected function _reindexRootCategory(Mage_Core_Model_Store $store)
+    {
+        // Optimization: don't do anything if there are no categories in the limit.
+        // We would add a IN (NULL) anyway, so we would do nothing.
+        if (!empty($this->_limitationByCategories)) {
+            return parent::_reindexRootCategory($store);
+        }
     }
 }

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Row.php
@@ -4,6 +4,15 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Catego
     extends Enterprise_Catalog_Model_Index_Action_Catalog_Category_Product_Category_Refresh_Row
 {
     use SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect;
+    use SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck;
+
+    /**
+     * Publish data from tmp to index
+     */
+    protected function _publishData()
+    {
+        return $this->_publishDataWithCheck();
+    }
 
     /**
      * Retrieve a select for reindexing products of anchor categories

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Row.php
@@ -6,7 +6,7 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Catego
     use SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect;
 
     /**
-     * Retrieve select for reindex products of non anchor categories
+     * Retrieve a select for reindexing products of anchor categories
      *
      * @param Mage_Core_Model_Store $store
      * @return Varien_Db_Select

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
@@ -4,6 +4,15 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     extends Enterprise_Catalog_Model_Index_Action_Catalog_Category_Product_Refresh_Changelog
 {
     use SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect;
+    use SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck;
+
+    /**
+     * Publish data from tmp to index
+     */
+    protected function _publishData()
+    {
+        return $this->_publishDataWithCheck();
+    }
 
     /**
      * Retrieve a select for reindexing products of anchor categories

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
@@ -7,6 +7,13 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     use SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck;
 
     /**
+     * @var int Product count at which to use faster category tree index.
+     *
+     * At lower product counts, generating the tree index may not be worth it.
+     */
+    const MIN_PRODUCTS_FOR_CAT_TREE_INDEX = 300;
+
+    /**
      * Publish data from tmp to index
      */
     protected function _publishData()
@@ -22,6 +29,9 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
      */
     protected function _getAnchorCategoriesSelect(Mage_Core_Model_Store $store)
     {
+        if (count($this->_limitationByProducts) < static::MIN_PRODUCTS_FOR_CAT_TREE_INDEX) {
+            return parent::_getAnchorCategoriesSelect($store);
+        }
         $select = $this->_getFasterAnchorCategoriesSelect($store);
         return $select->where('ccp.product_id IN (?)', $this->_limitationByProducts);
     }

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
@@ -6,7 +6,7 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     use SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect;
 
     /**
-     * Retrieve select for reindex products of non anchor categories
+     * Retrieve a select for reindexing products of anchor categories
      *
      * @param Mage_Core_Model_Store $store
      * @return Varien_Db_Select
@@ -15,5 +15,47 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     {
         $select = $this->_getFasterAnchorCategoriesSelect($store);
         return $select->where('ccp.product_id IN (?)', $this->_limitationByProducts);
+    }
+
+    /**
+     * Reindex products of non anchor categories
+     *
+     * @param Mage_Core_Model_Store $store
+     */
+    protected function _reindexNonAnchorCategories(Mage_Core_Model_Store $store)
+    {
+        // Optimization: don't do anything if there are no categories in the limit.
+        // We would add a IN (NULL) anyway, so we would do nothing.
+        if (!empty($this->_limitationByProducts)) {
+            return parent::_reindexNonAnchorCategories($store);
+        }
+    }
+
+    /**
+     * Reindex products of anchor categories
+     *
+     * @param Mage_Core_Model_Store $store
+     */
+    protected function _reindexAnchorCategories(Mage_Core_Model_Store $store)
+    {
+        // Optimization: don't do anything if there are no categories in the limit.
+        // We would add a IN (NULL) anyway, so we would do nothing.
+        if (!empty($this->_limitationByProducts)) {
+            return parent::_reindexAnchorCategories($store);
+        }
+    }
+
+    /**
+     * Reindex all products to root category
+     *
+     * @param Mage_Core_Model_Store $store
+     */
+    protected function _reindexRootCategory(Mage_Core_Model_Store $store)
+    {
+        // Optimization: don't do anything if there are no categories in the limit.
+        // We would add a IN (NULL) anyway, so we would do nothing.
+        if (!empty($this->_limitationByProducts)) {
+            return parent::_reindexRootCategory($store);
+        }
     }
 }

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
@@ -22,6 +22,23 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     }
 
     /**
+     * Reindex category/product index by store
+     *
+     * @return $this
+     */
+    protected function _reindex()
+    {
+        if (!empty($this->_limitationByCategories)) {
+            return parent::_reindex();
+        } else {
+            $this->_beforeReindex();
+            $this->_afterReindex();
+
+            return $this;
+        }
+    }
+
+    /**
      * Retrieve a select for reindexing products of anchor categories
      *
      * @param Mage_Core_Model_Store $store

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Row.php
@@ -7,6 +7,13 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     use SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck;
 
     /**
+     * @var int Product count at which to use faster category tree index.
+     *
+     * At lower product counts, generating the tree index may not be worth it.
+     */
+    const MIN_PRODUCTS_FOR_CAT_TREE_INDEX = 300;
+
+    /**
      * Publish data from tmp to index
      */
     protected function _publishData()
@@ -22,6 +29,9 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
      */
     protected function _getAnchorCategoriesSelect(Mage_Core_Model_Store $store)
     {
+        if (count($this->_limitationByProducts) < static::MIN_PRODUCTS_FOR_CAT_TREE_INDEX) {
+            return parent::_getAnchorCategoriesSelect($store);
+        }
         $select = $this->_getFasterAnchorCategoriesSelect($store);
         return $select->where('ccp.product_id IN (?)', $this->_limitationByProducts);
     }

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Row.php
@@ -6,7 +6,7 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     use SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect;
 
     /**
-     * Retrieve select for reindex products of non anchor categories
+     * Retrieve a select for reindexing products of anchor categories
      *
      * @param Mage_Core_Model_Store $store
      * @return Varien_Db_Select

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Row.php
@@ -4,6 +4,15 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     extends Enterprise_Catalog_Model_Index_Action_Catalog_Category_Product_Refresh_Row
 {
     use SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect;
+    use SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck;
+
+    /**
+     * Publish data from tmp to index
+     */
+    protected function _publishData()
+    {
+        return $this->_publishDataWithCheck();
+    }
 
     /**
      * Retrieve a select for reindexing products of anchor categories

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Trait/PublishDataCheck.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Trait/PublishDataCheck.php
@@ -1,0 +1,20 @@
+<?php
+
+trait SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck
+{
+    /**
+     * Publish data from tmp to index
+     */
+    protected function _publishDataWithCheck()
+    {
+        $selectCount = $this->_connection->select()
+            ->from($this->_getMainTmpTable())
+            ->columns('COUNT(category_id)');
+        $rows = $this->_connection->fetchOne($selectCount);
+
+        // If there's nothing to insert, let's not dirty the query cache.
+        if ($rows != 0) {
+            parent::_publishData();
+        }
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -10,11 +10,12 @@
         <models>
             <enterprise_catalog>
                 <rewrite>
+                    <index_action_catalog_category_product_category_refresh>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Category_Refresh</index_action_catalog_category_product_category_refresh>
                     <index_action_catalog_category_product_category_refresh_changelog>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Category_Refresh_Changelog</index_action_catalog_category_product_category_refresh_changelog>
                     <index_action_catalog_category_product_category_refresh_row>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Category_Refresh_Row</index_action_catalog_category_product_category_refresh_row>
+                    <index_action_catalog_category_product_refresh>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refresh</index_action_catalog_category_product_refresh>
                     <index_action_catalog_category_product_refresh_changelog>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refresh_Changelog</index_action_catalog_category_product_refresh_changelog>
                     <index_action_catalog_category_product_refresh_row>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refresh_Row</index_action_catalog_category_product_refresh_row>
-                    <index_action_catalog_category_product_refresh>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refresh</index_action_catalog_category_product_refresh>
                 </rewrite>
             </enterprise_catalog>
         </models>


### PR DESCRIPTION
Measured the performance of this more carefully with changelog handling, and found some areas for improvement:
1. When no rows were updated (somewhat common case), unnecessary work was being done.  The tree index also added a bit of extra overhead.  These changes now cut this back, reducing zero-row indexing time a lot and improving scaling compared to base Magento EE.
2. When a small number of products were updated (fairly common case), the tree index added about a 20% overhead.  The old way is now used when indexing a batch of less than 300 products, to prevent this.
3. As expected, the original optimization works great for partial category reindexing and large sets of products.
