### PR TITLE
Optimize URL rewrite indexes

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Category/Refresh.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Category/Refresh.php
@@ -1,0 +1,7 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Category_Refresh
+    extends Enterprise_Catalog_Model_Index_Action_Url_Rewrite_Category_Refresh
+{
+    use SomethingDigital_EnterpriseIndexPerf_Trait_Url_CategoryRewriteCache;
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Category/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Category/Refresh/Changelog.php
@@ -1,0 +1,7 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Category_Refresh_Changelog
+    extends Enterprise_Catalog_Model_Index_Action_Url_Rewrite_Category_Refresh_Changelog
+{
+    use SomethingDigital_EnterpriseIndexPerf_Trait_Url_CategoryRewriteCache;
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Category/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Category/Refresh/Row.php
@@ -1,0 +1,7 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Category_Refresh_Row
+    extends Enterprise_Catalog_Model_Index_Action_Url_Rewrite_Category_Refresh_Row
+{
+    use SomethingDigital_EnterpriseIndexPerf_Trait_Url_CategoryRewriteCache;
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Redirect/Refresh.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Redirect/Refresh.php
@@ -1,0 +1,65 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Redirect_Refresh
+    extends Enterprise_UrlRewrite_Model_Index_Action_Url_Rewrite_Redirect_Refresh
+{
+    const REWRITE_CHUNK_SIZE = 5000;
+
+    /**
+     * Clean old url rewrites records from table
+     *
+     * @return Enterprise_UrlRewrite_Model_Index_Action_Url_Rewrite_RefreshAbstract
+     */
+    protected function _cleanOldUrlRewrite()
+    {
+        $selects = $this->_prepareSelectsByRange($this->_getCleanOldUrlRewriteSelect(), 'url_rewrite_id');
+        foreach ($selects as $select) {
+            $this->_connection->query($select->deleteFromSelect('ur'));
+        }
+        return $this;
+    }
+
+    /**
+     * Refresh url rewrites
+     *
+     * @return Enterprise_UrlRewrite_Model_Index_Action_Url_Rewrite_RefreshAbstract
+     */
+    protected function _refreshUrlRewrite()
+    {
+        $selects = $this->_prepareSelectsByRange($this->_getUrlRewriteSelectSql(), 'redirect_id');
+        foreach ($selects as $select) {
+            $insert = $this->_connection->insertFromSelect($select,
+                $this->_getTable('enterprise_urlrewrite/url_rewrite'),
+                array(
+                    'request_path',
+                    'target_path',
+                    'guid',
+                    'is_system',
+                    'identifier',
+                    'value_id',
+                    'store_id',
+                    'entity_type'
+                )
+            );
+
+            $insert .= sprintf(' ON DUPLICATE KEY UPDATE %1$s = %1$s + 1',
+                $this->_getTable('enterprise_urlrewrite/url_rewrite') . '.inc');
+
+            $this->_connection->query($insert);
+        }
+        return $this;
+    }
+
+    /**
+     * Return selects cut by min and max
+     *
+     * @param Varien_Db_Select $select
+     * @param string $field
+     * @param int $range
+     * @return array
+     */
+    protected function _prepareSelectsByRange(Varien_Db_Select $select, $field, $range = self::REWRITE_CHUNK_SIZE)
+    {
+        return $this->_connection->selectsByRange($field, $select, $range);
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Redirect/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Url/Rewrite/Redirect/Refresh/Changelog.php
@@ -1,0 +1,44 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Redirect_Refresh_Changelog
+    extends Enterprise_UrlRewrite_Model_Index_Action_Url_Rewrite_Redirect_Refresh_Changelog
+{
+    /**
+     * Clean old url rewrites records from table
+     *
+     * @return $this
+     */
+    protected function _cleanOldUrlRewrite()
+    {
+        if (count($this->_getChangedIds()) != 0) {
+            return parent::_cleanOldUrlRewrite();
+        }
+        return $this;
+    }
+
+    /**
+     * Refresh url rewrites
+     *
+     * @return $this
+     */
+    protected function _refreshUrlRewrite()
+    {
+        if (count($this->_getChangedIds()) != 0) {
+            return parent::_refreshUrlRewrite();
+        }
+        return $this;
+    }
+
+    /**
+     * Refresh redirect to url rewrite relations
+     *
+     * @return $this
+     */
+    protected function _refreshRelation()
+    {
+        if (count($this->_getChangedIds()) != 0) {
+            return parent::_refreshRelation();
+        }
+        return $this;
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Trait/Url/CategoryRewriteCache.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Trait/Url/CategoryRewriteCache.php
@@ -1,0 +1,89 @@
+<?php
+
+trait SomethingDigital_EnterpriseIndexPerf_Trait_Url_CategoryRewriteCache
+{
+    protected $_cachedStoreSpecificData = array();
+
+    /**
+     * Set store specific data to category
+     *
+     * @param Mage_Catalog_Model_Category $category
+     * @param Mage_Core_Model_Store $store
+     * @return Mage_Catalog_Model_Category
+     */
+    protected function _setStoreSpecificData(Mage_Catalog_Model_Category $category, Mage_Core_Model_Store $store)
+    {
+        $category->setStoreId($store->getId());
+        // Load preloaded store-specific data.
+        $storeCategoryData = $this->_getCachedStoreSpecificData($category, $store);
+        if ($storeCategoryData) {
+            foreach ($storeCategoryData->toArray() as $key => $data) {
+                $category->setData($key, $data);
+            }
+        }
+        $rewrites = $this->_categoryRelation->loadByCategory($category);
+        $category->setRequestPath($rewrites->getRequestPath());
+        return $category;
+    }
+
+    /**
+     * Recursively index categories tree
+     *
+     * @param Mage_Catalog_Model_Category $category
+     * @param Mage_Core_Model_Store $store
+     * @return Enterprise_Catalog_Model_Index_Action_Url_Rewrite_Category_Refresh
+     */
+    protected function _indexCategoriesRecursively(Mage_Catalog_Model_Category $category, Mage_Core_Model_Store $store)
+    {
+        $category = $this->_setStoreSpecificData($category, $store);
+        //skip root and default categories
+        if ($category->getLevel() > 1) {
+            $category = $this->_formatUrlKey($category);
+            if ($category->getUrlKey()) {
+                $category = $this->_reindexCategoryUrlKey($category, $store);
+            }
+        }
+
+        if ($category->getChildrenCount()) {
+            /** @var Mage_Catalog_Model_Resource_Category_Collection $categoryCollection */
+            $categoryCollection = $category->getChildrenCategoriesWithInactive();
+            $categoryCollection->setDisableFlat(true);
+            // Preload child category data as an array.
+            $this->_preloadStoreSpecificData($categoryCollection, $store);
+            /** @var Mage_Catalog_Model_Category $childCategory */
+            foreach ($categoryCollection as $childCategory) {
+                $childCategory->setUrlKey($category->getUrlKey());
+                $childCategory->setParentUrl($category->getRequestPath());
+                $this->_indexCategoriesRecursively($childCategory, $store);
+            }
+        }
+
+        return $this;
+    }
+
+    protected function _preloadStoreSpecificData($categories, $store)
+    {
+        $storeId = $store->getId();
+        $cached = &$this->_cachedStoreSpecificData[$storeId];
+        if (!isset($cached)) {
+            $cached = array();
+        }
+
+        $categoryIds = array();
+        foreach ($categories as $category) {
+            $categoryIds[] = is_object($category) ? $category->getId() : $category;
+        }
+        $cached += $this->_urlResource->getCategories($categoryIds, $storeId);
+    }
+
+    protected function _getCachedStoreSpecificData($category, $store)
+    {
+        $storeId = $store->getId();
+        $categoryId = $category->getId();
+        $cached = &$this->_cachedStoreSpecificData[$storeId];
+        if (empty($cached) || !isset($cached[$categoryId])) {
+            return $this->_urlResource->getCategory($categoryId, $storeId);
+        }
+        return $cached[$categoryId];
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -22,6 +22,9 @@
                     <index_action_catalog_category_product_refresh>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refresh</index_action_catalog_category_product_refresh>
                     <index_action_catalog_category_product_refresh_changelog>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refresh_Changelog</index_action_catalog_category_product_refresh_changelog>
                     <index_action_catalog_category_product_refresh_row>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refresh_Row</index_action_catalog_category_product_refresh_row>
+                    <index_action_url_rewrite_category_refresh>SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Category_Refresh</index_action_url_rewrite_category_refresh>
+                    <index_action_url_rewrite_category_refresh_changelog>SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Category_Refresh_Changelog</index_action_url_rewrite_category_refresh_changelog>
+                    <index_action_url_rewrite_category_refresh_row>SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Category_Refresh_Row</index_action_url_rewrite_category_refresh_row>
                 </rewrite>
             </enterprise_catalog>
 

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -24,6 +24,12 @@
                     <index_action_catalog_category_product_refresh_row>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refresh_Row</index_action_catalog_category_product_refresh_row>
                 </rewrite>
             </enterprise_catalog>
+
+            <enterprise_urlrewrite>
+                <rewrite>
+                    <index_action_url_rewrite_redirect_refresh>SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Redirect_Refresh</index_action_url_rewrite_redirect_refresh>
+                </rewrite>
+            </enterprise_urlrewrite>
         </models>
     </global>
 </config>

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -28,6 +28,7 @@
             <enterprise_urlrewrite>
                 <rewrite>
                     <index_action_url_rewrite_redirect_refresh>SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Redirect_Refresh</index_action_url_rewrite_redirect_refresh>
+                    <index_action_url_rewrite_redirect_refresh_changelog>SomethingDigital_EnterpriseIndexPerf_Model_Url_Rewrite_Redirect_Refresh_Changelog</index_action_url_rewrite_redirect_refresh_changelog>
                 </rewrite>
             </enterprise_urlrewrite>
         </models>


### PR DESCRIPTION
With the optimizations that make category/product reindexing fast, URL rewrites are now near the top of full reindex time on some sites.

These changes improve partial and full reindexing for both URL redirects and category URL rewrites.  Obviously makes the biggest difference when you have a large number, as many large Magento sites do.
