### PR TITLE
Improve bundle price reindex, fix major perf/lock issue

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Bundle/Price/Refresh.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Bundle/Price/Refresh.php
@@ -1,0 +1,162 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Bundle_Price_Refresh
+    extends Mage_Bundle_Model_Resource_Indexer_Price
+{
+    const ENTITY_CHUNK_SIZE = 200;
+
+    /**
+     * Calculate bundle product selections price by product type
+     *
+     * @param int $priceType
+     * @return Mage_Bundle_Model_Resource_Indexer_Price
+     */
+    protected function _calculateBundleSelectionPrice($priceType)
+    {
+        $write = $this->_getWriteAdapter();
+
+        if ($priceType == Mage_Bundle_Model_Product_Price::PRICE_TYPE_FIXED) {
+
+            $selectionPriceValue = $write->getCheckSql(
+                'bsp.selection_price_value IS NULL',
+                'bs.selection_price_value',
+                'bsp.selection_price_value'
+            );
+            $selectionPriceType = $write->getCheckSql(
+                'bsp.selection_price_type IS NULL',
+                'bs.selection_price_type',
+                'bsp.selection_price_type'
+            );
+            $priceExpr = new Zend_Db_Expr(
+                $write->getCheckSql(
+                    $selectionPriceType . ' = 1',
+                    'ROUND(i.price * (' . $selectionPriceValue . ' / 100),2)',
+                    $write->getCheckSql(
+                        'i.special_price > 0 AND i.special_price < 100',
+                        'ROUND(' . $selectionPriceValue . ' * (i.special_price / 100),2)',
+                        $selectionPriceValue
+                    )
+                ) . '* bs.selection_qty'
+            );
+
+            $tierExpr = $write->getCheckSql(
+                'i.base_tier IS NOT NULL',
+                $write->getCheckSql(
+                    $selectionPriceType .' = 1',
+                    'ROUND(i.base_tier - (i.base_tier * (' . $selectionPriceValue . ' / 100)),2)',
+                    $write->getCheckSql(
+                        'i.tier_percent > 0',
+                        'ROUND(' . $selectionPriceValue
+                        . ' - (' . $selectionPriceValue . ' * (i.tier_percent / 100)),2)',
+                        $selectionPriceValue
+                    )
+                ) . ' * bs.selection_qty',
+                'NULL'
+            );
+
+            $groupExpr = $write->getCheckSql(
+                'i.base_group_price IS NOT NULL',
+                $write->getCheckSql(
+                    $selectionPriceType .' = 1',
+                    $priceExpr,
+                    $write->getCheckSql(
+                        'i.group_price_percent > 0',
+                        'ROUND(' . $selectionPriceValue
+                        . ' - (' . $selectionPriceValue . ' * (i.group_price_percent / 100)),2)',
+                        $selectionPriceValue
+                    )
+                ) . ' * bs.selection_qty',
+                'NULL'
+            );
+            $priceExpr = new Zend_Db_Expr(
+                $write->getCheckSql("{$groupExpr} < {$priceExpr}", $groupExpr, $priceExpr)
+            );
+        } else {
+            $priceExpr = new Zend_Db_Expr(
+                $write->getCheckSql(
+                    'i.special_price > 0 AND i.special_price < 100',
+                    'ROUND(idx.min_price * (i.special_price / 100), 2)',
+                    'idx.min_price'
+                ) . ' * bs.selection_qty'
+            );
+            $tierExpr = $write->getCheckSql(
+                'i.base_tier IS NOT NULL',
+                'ROUND(idx.min_price * (i.base_tier / 100), 2)* bs.selection_qty',
+                'NULL'
+            );
+            $groupExpr = $write->getCheckSql(
+                'i.base_group_price IS NOT NULL',
+                'ROUND(idx.min_price * (i.base_group_price / 100), 2)* bs.selection_qty',
+                'NULL'
+            );
+            $groupPriceExpr = new Zend_Db_Expr(
+                $write->getCheckSql(
+                    'i.base_group_price IS NOT NULL AND i.base_group_price > 0 AND i.base_group_price < 100',
+                    'ROUND(idx.min_price - idx.min_price * (i.base_group_price / 100), 2)',
+                    'idx.min_price'
+                ) . ' * bs.selection_qty'
+            );
+            $priceExpr = new Zend_Db_Expr(
+                $write->getCheckSql("{$groupPriceExpr} < {$priceExpr}", $groupPriceExpr, $priceExpr)
+            );
+        }
+
+        $select = $write->select()
+            ->from(
+                array('i' => $this->_getBundlePriceTable()),
+                array('entity_id', 'customer_group_id', 'website_id')
+            )
+            ->join(
+                array('bo' => $this->getTable('bundle/option')),
+                'bo.parent_id = i.entity_id',
+                array('option_id')
+            )
+            ->join(
+                array('bs' => $this->getTable('bundle/selection')),
+                'bs.option_id = bo.option_id',
+                array('selection_id')
+            )
+            ->joinLeft(
+                array('bsp' => $this->getTable('bundle/selection_price')),
+                'bs.selection_id = bsp.selection_id AND bsp.website_id = i.website_id',
+                array('')
+            )
+            ->join(
+                array('idx' => $this->getIdxTable()),
+                'bs.product_id = idx.entity_id AND i.customer_group_id = idx.customer_group_id'
+                . ' AND i.website_id = idx.website_id',
+                array()
+            )
+            ->join(
+                array('e' => $this->getTable('catalog/product')),
+                'bs.product_id = e.entity_id AND e.required_options=0',
+                array()
+            )
+            ->where('i.price_type=?', $priceType)
+            ->columns(array(
+                'group_type'    => $write->getCheckSql(
+                    "bo.type = 'select' OR bo.type = 'radio'",
+                    '0',
+                    '1'
+                ),
+                'is_required'   => 'bo.required',
+                'price'         => $priceExpr,
+                'tier_price'    => $tierExpr,
+                'group_price'   => $groupExpr,
+            ));
+
+        $selectEntityIds = $write->select()
+            ->distinct()
+            ->from($this->_getBundlePriceTable(), array('entity_id'));
+        $entityIds = $write->fetchCol($selectEntityIds);
+
+        $entityIdChunks = array_chunk($entityIds, static::ENTITY_CHUNK_SIZE);
+        foreach ($entityIdChunks as $entityIds) {
+            $chunkSelect = clone $select;
+            $chunkSelect->where('i.entity_id IN (?)', $entityIds);
+            $write->query($chunkSelect->insertFromSelect($this->_getBundleSelectionTable()));
+        }
+
+        return $this;
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -8,6 +8,12 @@
 
     <global>
         <models>
+            <bundle_resource>
+                <rewrite>
+                    <indexer_price>SomethingDigital_EnterpriseIndexPerf_Model_Bundle_Price_Refresh</indexer_price>
+                </rewrite>
+            </bundle_resource>
+
             <enterprise_catalog>
                 <rewrite>
                     <index_action_catalog_category_product_category_refresh_changelog>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Category_Refresh_Changelog</index_action_catalog_category_product_category_refresh_changelog>


### PR DESCRIPTION
I have a database dump that can reproduce the lock issue (SD internal use only, contains cleaned production data.)

This was tricky - I'm glad I was using MariaDB when testing because `SHOW EXPLAIN FOR` really made the issue much clearer for me.  Outside the index process, the query would often run fine, but in my case the lock was reproducible every time during the reindex.

I know that on production, we saw this taking > 1000 seconds and blocking orders.  I never let it complete on my local, but it was in the same realm.  This change makes it take seconds on my local.

Note that only certain product configurations (with bundles) are affected by this issue.  Even when the locking doesn't occur, these changes make reindexing even a small number of bundles faster.
