### PR TITLE
Improve performance when reindexing many products

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
@@ -7,6 +7,22 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Catego
     use SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck;
 
     /**
+     * Run reindex
+     *
+     * @return $this
+     * @throws Enterprise_Index_Model_Action_Exception
+     */
+    public function execute()
+    {
+        if (!empty($this->_limitationByCategories)) {
+            // Sometimes the same category will be in the changelog many times over.
+            $this->_limitationByCategories = array_values(array_unique($this->_limitationByCategories));
+        }
+
+        return parent::execute();
+    }
+
+    /**
      * Publish data from tmp to index
      */
     protected function _publishData()

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Row.php
@@ -7,6 +7,22 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Catego
     use SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck;
 
     /**
+     * Run reindex
+     *
+     * @return $this
+     * @throws Enterprise_Index_Model_Action_Exception
+     */
+    public function execute()
+    {
+        if (!empty($this->_limitationByCategories)) {
+            // Sometimes the same category will be in the changelog many times over.
+            $this->_limitationByCategories = array_values(array_unique($this->_limitationByCategories));
+        }
+
+        return parent::execute();
+    }
+
+    /**
      * Publish data from tmp to index
      */
     protected function _publishData()

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
@@ -14,6 +14,22 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     const MIN_PRODUCTS_FOR_CAT_TREE_INDEX = 300;
 
     /**
+     * Run reindex
+     *
+     * @return $this
+     * @throws Enterprise_Index_Model_Action_Exception
+     */
+    public function execute()
+    {
+        if (!empty($this->_limitationByProducts)) {
+            // Sometimes the same product will be in the changelog many times over.
+            $this->_limitationByProducts = array_values(array_unique($this->_limitationByProducts));
+        }
+
+        return parent::execute();
+    }
+
+    /**
      * Publish data from tmp to index
      */
     protected function _publishData()

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Row.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Row.php
@@ -14,6 +14,22 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     const MIN_PRODUCTS_FOR_CAT_TREE_INDEX = 300;
 
     /**
+     * Run reindex
+     *
+     * @return $this
+     * @throws Enterprise_Index_Model_Action_Exception
+     */
+    public function execute()
+    {
+        if (!empty($this->_limitationByProducts)) {
+            // Sometimes the same product will be in the changelog many times over.
+            $this->_limitationByProducts = array_values(array_unique($this->_limitationByProducts));
+        }
+
+        return parent::execute();
+    }
+
+    /**
      * Publish data from tmp to index
      */
     protected function _publishData()

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Observer/PageCache.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Observer/PageCache.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * PageCache short summary.
+ *
+ * PageCache description.
+ *
+ * @version 1.0
+ * @author Unknown
+ */
+class SomethingDigital_EnterpriseIndexPerf_Model_Observer_Pagecache
+{
+    /**
+     * Clean cache for affected products
+     *
+     * @param Varien_Event_Observer $observer Event data
+     */
+    public function cleanProductsCacheAfterPartialReindex(Varien_Event_Observer $observer)
+    {
+        // Only if the PageCache is enabled.
+        if (!Mage::helper('core')->isModuleEnabled('Enterprise_PageCache')) {
+            return;
+        }
+
+        $entityIds = $observer->getEvent()->getProductIds();
+        if (is_array($entityIds) && !empty($entityIds)) {
+            $this->_cleanProductsCache(Mage::getModel('catalog/product'), $entityIds);
+        }
+    }
+
+    /**
+     * Clean cache by specified product and its ids
+     *
+     * @param Mage_Core_Model_Abstract $entity Base entity model
+     * @param int[] $ids Product IDs
+     */
+    protected function _cleanProductsCache(Mage_Core_Model_Abstract $entity, array $ids)
+    {
+        $cacheTags = array();
+        foreach ($ids as $entityId) {
+            $entity->setId($entityId);
+            $productTags = $entity->getCacheIdTagsWithCategories();
+            foreach ($productTags as $tag) {
+                $cacheTags[$tag] = $tag;
+            }
+        }
+        if (!empty($cacheTags)) {
+            $cacheTags = array_values($cacheTags);
+            Enterprise_PageCache_Model_Cache::getCacheInstance()->clean($cacheTags);
+        }
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -35,5 +35,49 @@
                 </rewrite>
             </enterprise_urlrewrite>
         </models>
+
+        <events>
+            <!-- Override PageCache reindexing to optimize product invalidation on reindex. -->
+            <cataloginventory_stock_partial_reindex>
+                <observers>
+                    <enterprise_pagecache>
+                        <class>sd_enterpriseindexperf/observer_pagecache</class>
+                        <method>cleanProductsCacheAfterPartialReindex</method>
+                    </enterprise_pagecache>
+                </observers>
+            </cataloginventory_stock_partial_reindex>
+            <catalog_product_price_partial_reindex>
+                <observers>
+                    <enterprise_pagecache>
+                        <class>sd_enterpriseindexperf/observer_pagecache</class>
+                        <method>cleanProductsCacheAfterPartialReindex</method>
+                    </enterprise_pagecache>
+                </observers>
+            </catalog_product_price_partial_reindex>
+            <catalog_product_flat_partial_reindex>
+                <observers>
+                    <enterprise_pagecache>
+                        <class>sd_enterpriseindexperf/observer_pagecache</class>
+                        <method>cleanProductsCacheAfterPartialReindex</method>
+                    </enterprise_pagecache>
+                </observers>
+            </catalog_product_flat_partial_reindex>
+            <catalog_category_product_partial_reindex>
+                <observers>
+                    <enterprise_pagecache>
+                        <class>sd_enterpriseindexperf/observer_pagecache</class>
+                        <method>cleanProductsCacheAfterPartialReindex</method>
+                    </enterprise_pagecache>
+                </observers>
+            </catalog_category_product_partial_reindex>
+            <catalog_url_product_partial_reindex>
+                <observers>
+                    <enterprise_pagecache>
+                        <class>sd_enterpriseindexperf/observer_pagecache</class>
+                        <method>cleanProductsCacheAfterPartialReindex</method>
+                    </enterprise_pagecache>
+                </observers>
+            </catalog_url_product_partial_reindex>
+        </events>
     </global>
 </config>


### PR DESCRIPTION
When a large number of products were in a changelog, performance was suffering due to FPC cache clear related activity.

This generally optimizes this use case.  We were seeing a set of 5000 products repeated an average of 1.2x times in the changelog, each in many categories.  This change reduced the time in enterprise_refresh_index significantly.
