### PR TITLE
Add an index for bundle selection by parent

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -2,12 +2,28 @@
 <config>
     <modules>
         <SomethingDigital_EnterpriseIndexPerf>
-            <version>1.1.1</version>
+            <version>1.1.2</version>
         </SomethingDigital_EnterpriseIndexPerf>
     </modules>
 
     <global>
+        <resources>
+            <sd_enterpriseindexperf_setup>
+                <setup>
+                    <module>SomethingDigital_EnterpriseIndexPerf</module>
+                    <class>Mage_Core_Model_Resource_Setup</class>
+                </setup>
+                <connection>
+                    <use>setup</use>
+                </connection>
+            </sd_enterpriseindexperf_setup>
+        </resources>
+
         <models>
+            <sd_enterpriseindexperf>
+                <class>SomethingDigital_EnterpriseIndexPerf_Model</class>
+            </sd_enterpriseindexperf>
+
             <bundle_resource>
                 <rewrite>
                     <indexer_price>SomethingDigital_EnterpriseIndexPerf_Model_Bundle_Price_Refresh</indexer_price>

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/sql/sd_enterpriseindexperf_setup/install-1.1.2.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/sql/sd_enterpriseindexperf_setup/install-1.1.2.php
@@ -1,0 +1,11 @@
+<?php
+
+/** @var Mage_Core_Model_Resource_Setup $this */
+$this->startSetup();
+
+$selectionTable = $this->getTable('bundle/selection');
+$indexColumns = array('parent_product_id', 'product_id');
+$indexName = $this->getIdxName('bundle/selection', $indexColumns);
+$this->getConnection()->addIndex($selectionTable, $indexName, $indexColumns);
+
+$this->endSetup();


### PR DESCRIPTION
With a large number of selections (6 figures), this lookup can really slow down search index processing.  This greatly improves that.
