### PR TITLE
Avoid writes in common merchandiser sort actions

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser.php
@@ -1,0 +1,53 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser
+{
+    /**
+     * newestFirst sort action.
+     *
+     * @param array $params Sorting parameters.
+     * @return void
+     */
+    public function newestFirst($params)
+    {
+        $catId = $params['catId'];
+        /** @var OnTap_Merchandiser_Model_Resource_Merchandiser $merchandiserResourceModel */
+        $merchandiserResourceModel = Mage::getResourceModel('merchandiser/merchandiser');
+
+        $categoryProducts = $merchandiserResourceModel->getCategoryProduct($catId, "product_id DESC");
+        $position = 1;
+        foreach ($categoryProducts as $product) {
+            // Only apply an update if it actually changed.  It's common that this won't change.
+            if ($product['position'] != $position) {
+                $merchandiserResourceModel->updateProductPosition($catId, $product['product_id'], $position);
+            }
+            $position++;
+        }
+    }
+
+    /**
+     * moveInStockToTheTop sort action.
+     *
+     * @param array $params Sorting parameters.
+     * @return void
+     */
+    public function moveInStockToTheTop($params)
+    {
+        $catId = $params['catId'];
+        /** @var OnTap_Merchandiser_Model_Resource_Merchandiser $merchandiserResourceModel */
+        $merchandiserResourceModel = Mage::getResourceModel('merchandiser/merchandiser');
+        $outStockProducts = $merchandiserResourceModel->getOutofStockProducts($catId);
+
+        $maxPosition = $merchandiserResourceModel->getMaxInstockPositionFromCategory($catId);
+
+        if (count($outStockProducts)) {
+            foreach ($outStockProducts as $outStockProduct) {
+                $outStockProductId = $outStockProduct['product_id'];
+                ++$maxPosition;
+                if ($outStockProduct['position'] != $maxPosition) {
+                    $merchandiserResourceModel->updateProductPosition($catId, $outStockProductId, $maxPosition);
+                }
+            }
+        }
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -96,4 +96,20 @@
             </catalog_url_product_partial_reindex>
         </events>
     </global>
+
+    <default>
+        <catalog>
+            <!-- This section does nothing if the Merchandiser is disabled. -->
+            <merchandiser>
+                <actions>
+                    <newest>
+                        <sorting_function>SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser::newestFirst</sorting_function>
+                    </newest>
+                    <instock_at_top>
+                        <sorting_function>SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser::moveInStockToTheTop</sorting_function>
+                    </instock_at_top>
+                </actions>
+            </merchandiser>
+        </catalog>
+    </default>
 </config>


### PR DESCRIPTION
When the merchandiser has automatic sorting enabled, it by default updates every product's position on a cron.

Ignoring the inefficiency of the cron, this causes the index to be dirtied, and ultimately results in those products being cleared from the FPC.  Obviously, this is bad for performance and causes needless amounts of reindexing as well.
