### PR TITLE
Utilize the enterprise indexes for smart categories

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
@@ -18,7 +18,7 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Indexer extends On
 
         if (empty($heroProducts) && $categoryValues['smart_attributes'] == '') {
             // Nothing to do, this is probably only configured to sort.
-            // This is a common configuration in some cases.
+            // This is a common configuration on some stores.
             return false;
         }
 
@@ -57,9 +57,17 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Indexer extends On
                     $newProducts[$productId] = $iCounter++;
                 }
             }
+        } else {
+            // Apply existing rule-based products in the same order they were in before.
+            $ruledLookup = array_flip($ruledProductIds);
+            foreach ($existingProducts as $productId => $position) {
+                if (!isset($newProducts[$productId]) && isset($ruledLookup[$productId])) {
+                    $newProducts[$productId] = $iCounter++;
+                }
+            }
         }
 
-        // Place any remaining products at the bottom.  This may include existing products when ruled_only.
+        // Place any remaining products at the bottom.
         foreach ($ruledProductIds as $productId) {
             if (!isset($newProducts[$productId])) {
                 $newProducts[$productId] = $iCounter++;

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
@@ -36,7 +36,9 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Indexer extends On
             $newProducts[$productId] = $iCounter++;
         }
 
-        $ruledProductIds = $helper->smartFilter($categoryId, $categoryValues['smart_attributes']);
+        // The category is no longer used.  Let's pass in a blank one with the id.
+        $category = Mage::getModel('catalog/category')->setId($categoryId);
+        $ruledProductIds = $helper->smartFilter($category, $categoryValues['smart_attributes']);
 
         $addTo = $helper->newProductsHandler(); // 1= TOP , 2 = BOTTOM
         if ($addTo <= 1) {

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
@@ -14,6 +14,14 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Indexer extends On
             $categoryValues['ruled_only'] = 0;
         }
 
+        $heroProducts = $this->getHeroProductIds($categoryValues);
+
+        if (empty($heroProducts) && $categoryValues['smart_attributes'] == '') {
+            // Nothing to do, this is probably only configured to sort.
+            // This is a common configuration in some cases.
+            return false;
+        }
+
         $categoryProductsResult = $merchandiserResourceModel->getCategoryProduct($categoryId);
         $existingProducts = array();
         foreach ($categoryProductsResult as $productInfo) {
@@ -24,7 +32,6 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Indexer extends On
         $newProducts = array();
         $iCounter = 1;
 
-        $heroProducts = $this->getHeroProductIds($categoryValues);
         foreach ($heroProducts as $productId) {
             $newProducts[$productId] = $iCounter++;
         }

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
@@ -6,14 +6,136 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Indexer extends On
     {
         /** @var OnTap_Merchandiser_Model_Resource_Merchandiser $merchandiserResourceModel */
         $merchandiserResourceModel = Mage::getResourceModel('merchandiser/merchandiser');
-        $merchandiserResourceModel->beginTransaction();
-        $this->affectCategoryBySmartRule($categoryId);
-        $merchandiserResourceModel->commit();
+        /** @var OnTap_Merchandiser_Helper_Data $helper */
+        $helper = Mage::helper('merchandiser');
+
+        $categoryValues = $merchandiserResourceModel->getCategoryValues($categoryId);
+        if ($categoryValues['smart_attributes'] == '') {
+            $categoryValues['ruled_only'] = 0;
+        }
+
+        $categoryProductsResult = $merchandiserResourceModel->getCategoryProduct($categoryId);
+        $existingProducts = array();
+        foreach ($categoryProductsResult as $productInfo) {
+            $existingProducts[$productInfo['product_id']] = $productInfo['position'];
+        }
+        asort($existingProducts);
+
+        $newProducts = array();
+        $iCounter = 1;
+
+        $heroProducts = $this->getHeroProductIds($categoryValues);
+        foreach ($heroProducts as $productId) {
+            $newProducts[$productId] = $iCounter++;
+        }
+
+        $ruledProductIds = $helper->smartFilter($categoryId, $categoryValues['smart_attributes']);
+
+        $addTo = $helper->newProductsHandler(); // 1= TOP , 2 = BOTTOM
+        if ($addTo <= 1) {
+            foreach ($ruledProductIds as $productId) {
+                // Move any new products to the top.  Leave existing where they are.
+                if (!isset($newProducts[$productId]) && !isset($existingProducts[$productId])) {
+                    $newProducts[$productId] = $iCounter++;
+                }
+            }
+        }
+
+        if ($categoryValues['ruled_only'] == 0) {
+            // These are already in sorted order.  Don't move hero products down, though.
+            foreach ($existingProducts as $productId => $position) {
+                if (!isset($newProducts[$productId])) {
+                    $newProducts[$productId] = $iCounter++;
+                }
+            }
+        }
+
+        // Place any remaining products at the bottom.  This may include existing products when ruled_only.
+        foreach ($ruledProductIds as $productId) {
+            if (!isset($newProducts[$productId])) {
+                $newProducts[$productId] = $iCounter++;
+            }
+        }
+
+        // Don't apply sorting logic if it's going to be resorted later anyway.
+        $shouldApplySort = !in_array($categoryValues['automatic_sort'], array(
+            'newest',
+            'highest_margin',
+        ));
+        return $this->applyChanges($categoryId, $shouldApplySort, $existingProducts, $newProducts);
     }
 
     public function reindexCategoryProducts($categoryId, $productIds)
     {
-        $this->reindexCategory($categoryId);
-        return true;
+        // TODO: Make this smarter?  Have to rewrite more for any extra perf.
+        return $this->reindexCategory($categoryId);
+    }
+
+    protected function getHeroProductIds($categoryValues)
+    {
+        $skus = explode(',', $categoryValues['heroproducts']);
+        $skus = array_filter(array_map('trim', $skus));
+
+        $productIds = array();
+        if (!empty($skus)) {
+            $productObject = Mage::getModel('catalog/product');
+            foreach ($skus as $sku) {
+                $productId = $productObject->getIdBySku($sku);
+                if ($productId) {
+                    // Let's keep it unique.  This will sort by first appearance.
+                    $productIds[$productId] = $productId;
+                }
+            }
+        }
+
+        return array_values($productIds);
+    }
+
+    protected function applyChanges($categoryId, $shouldApplySort, $existingProducts, $newProducts)
+    {
+        $deletes = array();
+        $inserts = array();
+
+        foreach ($newProducts as $productId => $position) {
+            if (!isset($existingProducts[$productId])) {
+                // New product: insert.
+                $inserts[] = array(
+                    'category_id' => $categoryId,
+                    'product_id' => $productId,
+                    'position' => $position,
+                );
+            } elseif ($shouldApplySort && $existingProducts[$productId] != $position) {
+                // Changed position: delete and then insert.
+                $deletes[] = $productId;
+                $inserts[] = array(
+                    'category_id' => $categoryId,
+                    'product_id' => $productId,
+                    'position' => $position,
+                );
+            }
+        }
+        foreach ($existingProducts as $productId => $position) {
+            if (!isset($newProducts[$productId])) {
+                // Removed product: delete.
+                $deletes[] = $productId;
+            }
+        }
+
+        if (!empty($deletes) || !empty($inserts)) {
+            /** @var OnTap_Merchandiser_Model_Resource_Merchandiser $merchandiserResourceModel */
+            $merchandiserResourceModel = Mage::getResourceModel('merchandiser/merchandiser');
+
+            $merchandiserResourceModel->beginTransaction();
+            if (!empty($deletes)) {
+                $merchandiserResourceModel->deleteSpecificProducts($categoryId, implode(', ', $deletes));
+            }
+            if (!empty($inserts)) {
+                $merchandiserResourceModel->insertMultipleProductsToCategory($inserts);
+            }
+            $merchandiserResourceModel->commit();
+
+            return true;
+        }
+        return false;
     }
 }

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Indexer.php
@@ -1,0 +1,19 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Indexer extends OnTap_Merchandiser_Model_Merchandiser
+{
+    public function reindexCategory($categoryId)
+    {
+        /** @var OnTap_Merchandiser_Model_Resource_Merchandiser $merchandiserResourceModel */
+        $merchandiserResourceModel = Mage::getResourceModel('merchandiser/merchandiser');
+        $merchandiserResourceModel->beginTransaction();
+        $this->affectCategoryBySmartRule($categoryId);
+        $merchandiserResourceModel->commit();
+    }
+
+    public function reindexCategoryProducts($categoryId, $productIds)
+    {
+        $this->reindexCategory($categoryId);
+        return true;
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Sorting.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Merchandiser/Sorting.php
@@ -1,6 +1,6 @@
 <?php
 
-class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser
+class SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Sorting
 {
     /**
      * newestFirst sort action.

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Observer/Merchandiser.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Observer/Merchandiser.php
@@ -39,9 +39,11 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Observer_Merchandiser
         foreach ($categoryIds as $categoryId) {
             /** @var SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Indexer $merchandiser */
             $merchandiser = Mage::getModel('sd_enterpriseindexperf/merchandiser_indexer');
-            $merchandiser->reindexCategory($categoryId);
+            $changed = $merchandiser->reindexCategory($categoryId);
 
-            $merchandiserResourceModel->applySortAction($categoryId);
+            if ($changed) {
+                $merchandiserResourceModel->applySortAction($categoryId);
+            }
         }
     }
 

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Observer/Merchandiser.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Observer/Merchandiser.php
@@ -1,0 +1,58 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Observer_Merchandiser
+{
+    /**
+     * Run base cron only when necessary.
+     */
+    public function reindexCron()
+    {
+        // Following indexes only works when they're enabled.
+        // But when they are, we'll use events.
+        if (!$this->isFlatIndexerEnabled()) {
+            /** @var OnTap_Merchandiser_Model_Adminhtml_Observer $observer */
+            $observer = Mage::getSingleton('merchandiser/adminhtml_observer');
+            $observer->reindexCron();
+        }
+    }
+
+    /**
+     * Apply smart category updates for all products.
+     */
+    public function updateAllProducts()
+    {
+        /** @var OnTap_Merchandiser_Model_Resource_Merchandiser $merchandiserResourceModel */
+        $merchandiserResourceModel = Mage::getResourceModel('merchandiser/merchandiser');
+        $categoryValues = $merchandiserResourceModel->fetchCategoriesValues();
+
+        // Full reindex: rebuild all categories.
+        foreach ($categoryValues as $categoryVal) {
+            // Avoid ever having the category visibly empty, if possible.
+            $merchandiserResourceModel->beginTransaction();
+
+            /** @var OnTap_Merchandiser_Model_Merchandiser $merchandiser */
+            $merchandiser = Mage::getModel('merchandiser/merchandiser');
+            $merchandiser->affectCategoryBySmartRule($categoryVal['category_id']);
+            $merchandiserResourceModel->applySortAction($categoryVal['category_id']);
+
+            $merchandiserResourceModel->commit();
+        }
+    }
+
+    /**
+     * Apply smart category updates for selected products.
+     *
+     * @param Varien_Event_Observer $observer Event data
+     */
+    public function updateProducts(Varien_Event_Observer $observer)
+    {
+        // TODO: Only reindex products which were modified.
+        // $entityIds = $observer->getEvent()->getProductIds();
+        $this->updateAllProducts();
+    }
+
+    protected function isFlatIndexerEnabled()
+    {
+        return Mage::getStoreConfigFlag('catalog/frontend/flat_catalog_product');
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -76,6 +76,11 @@
                         <class>sd_enterpriseindexperf/observer_pagecache</class>
                         <method>cleanProductsCacheAfterPartialReindex</method>
                     </enterprise_pagecache>
+
+                    <sd_enterpriseindexperf_merchandiser>
+                        <class>sd_enterpriseindexperf/observer_merchandiser</class>
+                        <method>updateProducts</method>
+                    </sd_enterpriseindexperf_merchandiser>
                 </observers>
             </catalog_product_flat_partial_reindex>
             <catalog_category_product_partial_reindex>
@@ -94,6 +99,15 @@
                     </enterprise_pagecache>
                 </observers>
             </catalog_url_product_partial_reindex>
+
+            <catalog_product_flat_full_reindex>
+                <observers>
+                    <sd_enterpriseindexperf_merchandiser>
+                        <class>sd_enterpriseindexperf/observer_merchandiser</class>
+                        <method>updateAllProducts</method>
+                    </sd_enterpriseindexperf_merchandiser>
+                </observers>
+            </catalog_product_flat_full_reindex>
         </events>
     </global>
 
@@ -103,13 +117,23 @@
             <merchandiser>
                 <actions>
                     <newest>
-                        <sorting_function>SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser::newestFirst</sorting_function>
+                        <sorting_function>SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Sorting::newestFirst</sorting_function>
                     </newest>
                     <instock_at_top>
-                        <sorting_function>SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser::moveInStockToTheTop</sorting_function>
+                        <sorting_function>SomethingDigital_EnterpriseIndexPerf_Model_Merchandiser_Sorting::moveInStockToTheTop</sorting_function>
                     </instock_at_top>
                 </actions>
             </merchandiser>
         </catalog>
     </default>
+
+    <crontab>
+        <jobs>
+            <smart_merchandiser_reindex>
+                <run>
+                    <model>sd_enterpriseindexperf/observer_merchandiser::reindexCron</model>
+                </run>
+            </smart_merchandiser_reindex>
+        </jobs>
+    </crontab>
 </config>


### PR DESCRIPTION
This does a few important things:
1. If product flat is enabled, use its events to reindex smart categories.  This means it's cheaper when products aren't changing, but much more immediate when they do change.
2. Use a delta approach when updating smart category contents: only touch products that actually change (either in position, or membership in the category.)  This is a **critical change**, read below.
3. If a smart category is only smart to enable sorting, but does not apply any attribute logic, skip running membership updates entirely.  With delta updates, this is just an optimization to reduce runtime.

Note that when product category membership is changed:
- Query caches are flushed.
- The affected products are reindexed.
- The affected products are flushed from the FPC.

All of these would happen for _every product_ in a smart category, every time the smart category was reevaluated.  These changes, along with #10, prevent that so FPC and indexes are only touched for products that actually change.

This however does mean potentially more full smart category reindexes (e.g. when product data changes frequently.)  Based on testing, when the membership doesn't change or changes very little, this is fairly inexpensive even on a large catalog.
