### PR TITLE
Clean only unique product ids from the cache

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Observer/Pagecache.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Observer/Pagecache.php
@@ -23,12 +23,13 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Observer_Pagecache
     /**
      * Clean cache by specified product and its ids
      *
-     * @param Mage_Core_Model_Abstract $entity Base entity model
+     * @param Mage_Catalog_Model_Product $entity Base entity model
      * @param int[] $ids Product IDs
      */
-    protected function _cleanProductsCache(Mage_Core_Model_Abstract $entity, array $ids)
+    protected function _cleanProductsCache(Mage_Catalog_Model_Product $entity, array $ids)
     {
         $cacheTags = array();
+        $ids = array_unique($ids);
         foreach ($ids as $entityId) {
             $entity->setId($entityId);
             $productTags = $entity->getCacheIdTagsWithCategories();


### PR DESCRIPTION
This is related to other optimizations here.  Sometimes this observer receives a list with multiple product ids still - especially as the initial event.

`getCacheIdTagsWithCategories` is not expensive itself, but involves a db query for each product.  The cost of the array_unique is trivial compared to the savings if there's even a couple duplicates.
