### PR TITLE
Read unique changelog entries from the db

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Category/Refresh/Changelog.php
@@ -7,22 +7,6 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Catego
     use SomethingDigital_EnterpriseIndexPerf_Trait_PublishDataCheck;
 
     /**
-     * Run reindex
-     *
-     * @return $this
-     * @throws Enterprise_Index_Model_Action_Exception
-     */
-    public function execute()
-    {
-        if (!empty($this->_limitationByCategories)) {
-            // Sometimes the same category will be in the changelog many times over.
-            $this->_limitationByCategories = array_values(array_unique($this->_limitationByCategories));
-        }
-
-        return parent::execute();
-    }
-
-    /**
      * Publish data from tmp to index
      */
     protected function _publishData()

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Catalog/Category/Product/Refresh/Changelog.php
@@ -14,22 +14,6 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Refres
     const MIN_PRODUCTS_FOR_CAT_TREE_INDEX = 300;
 
     /**
-     * Run reindex
-     *
-     * @return $this
-     * @throws Enterprise_Index_Model_Action_Exception
-     */
-    public function execute()
-    {
-        if (!empty($this->_limitationByProducts)) {
-            // Sometimes the same product will be in the changelog many times over.
-            $this->_limitationByProducts = array_values(array_unique($this->_limitationByProducts));
-        }
-
-        return parent::execute();
-    }
-
-    /**
      * Publish data from tmp to index
      */
     protected function _publishData()

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Changelog.php
@@ -1,0 +1,27 @@
+<?php
+
+class SomethingDigital_EnterpriseIndexPerf_Model_Changelog extends Enterprise_Index_Model_Changelog
+{
+    /**
+     * Load changelog ids by metadata.
+     *
+     * This differs from the parent by adding a DISTINCT.
+     *
+     * @param null|int $currentVersion Version id to stop at.
+     * @return int[]
+     */
+    public function loadByMetadata($currentVersion = null)
+    {
+        $select = $this->_connection->select()
+            ->from(array('changelog' => $this->_metadata->getChangelogName()), array())
+            ->where('version_id >= ?', $this->_metadata->getVersionId())
+            ->columns(array($this->_metadata->getKeyColumn()))
+            ->distinct();
+
+        if ($currentVersion) {
+            $select->where('version_id < ?', $currentVersion);
+        }
+
+        return $this->_connection->fetchCol($select);
+    }
+}

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/etc/config.xml
@@ -30,6 +30,12 @@
                 </rewrite>
             </bundle_resource>
 
+            <enterprise_index>
+                <rewrite>
+                    <changelog>SomethingDigital_EnterpriseIndexPerf_Model_Changelog</changelog>
+                </rewrite>
+            </enterprise_index>
+
             <enterprise_catalog>
                 <rewrite>
                     <index_action_catalog_category_product_category_refresh>SomethingDigital_EnterpriseIndexPerf_Model_Catalog_Category_Product_Category_Refresh</index_action_catalog_category_product_category_refresh>


### PR DESCRIPTION
With this module, all callers were already doing an `array_unique`, and really it only makes sense to do that with a changelog.

This just makes that happen in MySQL.  We saw a changelog generate a memory_limit error on a site, motivating this change.

Note that this module makes other changes to reduce the frequency of duplicates within the changelog tables, which that site did not have.  Even so, it seems like a good idea to constraint the memory usage to at least the total count of products/etc.
