### PR TITLE
Correct error when a category is deleted

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Trait/Url/CategoryRewriteCache.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Trait/Url/CategoryRewriteCache.php
@@ -73,7 +73,10 @@ trait SomethingDigital_EnterpriseIndexPerf_Trait_Url_CategoryRewriteCache
         foreach ($categories as $category) {
             $categoryIds[] = is_object($category) ? $category->getId() : $category;
         }
-        $cached += $this->_urlResource->getCategories($categoryIds, $storeId);
+
+        if (!empty($categoryIds)) {
+            $cached += $this->_urlResource->getCategories($categoryIds, $storeId);
+        }
     }
 
     protected function _getCachedStoreSpecificData($category, $store)


### PR DESCRIPTION
The category URL index was able to hit an "unsupported operand types" error in certain scenarios, like when a category deletion occurred.

This is because `urlResource->getCategories` specifically returns `false` when passed an empty array of category ids, but otherwise always returns an array.
