### PR TITLE
Add compatibility with EE 1.14.3.x

### DIFF
--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Changelog.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Model/Changelog.php
@@ -14,12 +14,12 @@ class SomethingDigital_EnterpriseIndexPerf_Model_Changelog extends Enterprise_In
     {
         $select = $this->_connection->select()
             ->from(array('changelog' => $this->_metadata->getChangelogName()), array())
-            ->where('version_id >= ?', $this->_metadata->getVersionId())
+            ->where('version_id > ?', $this->_metadata->getVersionId())
             ->columns(array($this->_metadata->getKeyColumn()))
             ->distinct();
 
         if ($currentVersion) {
-            $select->where('version_id < ?', $currentVersion);
+            $select->where('version_id <= ?', $currentVersion);
         }
 
         return $this->_connection->fetchCol($select);

--- a/app/code/community/SomethingDigital/EnterpriseIndexPerf/Trait/FasterAnchorCategoriesSelect.php
+++ b/app/code/community/SomethingDigital/EnterpriseIndexPerf/Trait/FasterAnchorCategoriesSelect.php
@@ -20,6 +20,7 @@ trait SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect
             $visibilityAttributeId = $eavConfig->getAttribute(
                 Mage_Catalog_Model_Product::ENTITY, 'visibility'
             )->getId();
+            $entityTypeId = (int)$eavConfig->getEntityType(Mage_Catalog_Model_Category::ENTITY)->getEntityTypeId();
 
             $rootCatIds = explode('/', $this->_getPathFromCategoryId($store->getRootCategoryId()));
             array_pop($rootCatIds);
@@ -70,12 +71,14 @@ trait SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect
                 ->joinInner(
                     array('ccad' => $this->_getTable(array('catalog/category', 'int'))),
                     'ccad.entity_id = cc.entity_id AND ccad.store_id = 0'
+                        . ' AND ccad.entity_type_id = ' . $entityTypeId
                         . ' AND ccad.attribute_id = ' . $isAnchorAttributeId,
                     array()
                 )
                 ->joinLeft(
                     array('ccas' => $this->_getTable(array('catalog/category', 'int'))),
                     'ccas.entity_id = cc.entity_id AND ccas.attribute_id = ccad.attribute_id'
+                        . ' AND ccas.entity_type_id = ' . $entityTypeId
                         . ' AND ccas.store_id = ' . $store->getId(),
                     array()
                 )
@@ -112,5 +115,17 @@ trait SomethingDigital_EnterpriseIndexPerf_Trait_FasterAnchorCategoriesSelect
         }
 
         return $this->_anchorCategoriesSelect[$store->getId()];
+    }
+
+    protected function _getAnchorCategoriesSubSelect($store)
+    {
+        // Ignore EE 1.14.3.0's subselect slicing - our method is faster.
+        return $this->_getFasterAnchorCategoriesSelect($store);
+    }
+
+    protected function _getAnchorCategoriesSelectBySubSelect($select, $store)
+    {
+        // Ignore EE 1.14.3.0's subselect slicing - our method is faster.
+        return $select;
     }
 }


### PR DESCRIPTION
This improves compatibility with EE 1.14.3.0, by continuing to override its indexing logic.

A minor improvement from EE 1.14.3.0 is included (which is backwards compatible), but it has a very small impact to performance.

A test against a large product/category database:

EE 1.14.2.4: ~1000s
EE 1.14.3.0: ~100s
EnterpriseIndexPerf: ~20s (either EE version)
